### PR TITLE
feat: add routing by cookies

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -20,5 +20,9 @@ services:
         config:
           traffic_percentage_for_secondary: 30
           domain: k-8-s-test-k-8-s-az-test-staging-usa-cnguq.kwik-e-mart-main.az.kwik-e-mart-main.nullapps.io
-          upstream: test        
+          upstream: test
+          use_cookies:
+            max_age: 30
+            http_only: true
+            secure: true
           

--- a/np-traffic-splitter/handler.lua
+++ b/np-traffic-splitter/handler.lua
@@ -1,51 +1,164 @@
 local NpTrafficSplitterHandler = {
-	  VERSION = "1.0.0",
-	  PRIORITY = 1000,
+    VERSION = "1.0.0",
+    PRIORITY = 1000,
 }
+
+local UPSTREAM_FORCE_HEADER_NAME = "X-NP-Upstream"
+
+local function split(s, delimiter)
+    local delimiter = delimiter or '%s'
+    local t = {}
+    local i = 1
+    for str in string.gmatch(s, '([^'..delimiter..']+)') do
+        t[i] = str
+        i = i + 1
+    end
+    return t
+end
+
+local function force_upstream_by_header(expected_value)
+    return kong.request.get_header(UPSTREAM_FORCE_HEADER_NAME) == expected_value
+end
+
+local function eat_cookie(cookie)
+    local result = ""
+    for cookie_attr in string.gmatch(cookie, '([^'.."; "..']+)') do
+        if result == "" then
+            local key_val = split(cookie_attr, "=")
+            if key_val[1] == UPSTREAM_FORCE_HEADER_NAME then
+                result = key_val[2]
+                break
+            end
+        end
+    end
+    return result
+end
+
+local function force_upstream_by_cookie(cookies, expected_value)
+    local cookie_type = type(cookies)
+    local result = ""
+    if cookie_type == "string" then
+        result = eat_cookie(cookies)
+    elseif cookie_type == "table" then
+        local cookie_size = #cookies
+        for i = 1, cookie_size do
+            if result == "" then
+                result = eat_cookie(cookies[i])
+            end
+        end
+    end
+    return result == expected_value
+end
 
 function NpTrafficSplitterHandler:access(conf)
     local upstream_url
     local rand = math.random(100) -- Get a random number between 1 and 100
-    local choose_primary = kong.request.get_header("X-NP-Upstream") == "false"
-    local choose_secondary = kong.request.get_header("X-NP-Upstream") == "true"
+    -- Choose upstream by force header
+    local choose_primary = force_upstream_by_header("false")
+    local choose_secondary = force_upstream_by_header("true")
+    print("Target ", conf.upstream)
+    -- Choose upstream by cookie (only if conf contains use_cookies)
+    if not choose_primary and not choose_secondary and conf.use_cookies and conf.use_cookies.enabled and cookies then
+        local cookies = kong.request.get_header("Cookie")
+        choose_primary = force_upstream_by_cookie(cookies, "0")
+        choose_secondary = force_upstream_by_cookie(cookies, "1")
+    end
+
     -- Choose upstream according to random number or force secondary if request header is present
     if choose_secondary or (rand <= conf.traffic_percentage_for_secondary and not choose_primary)  then
         -- Send traffic to the secondary service based on the configured percentage
-        local domain = conf.domain
         kong.service.request.set_scheme(conf.schema)
         if conf.upstream then
             -- For Kong 3.X
-            kong.log.debug("Routing to secondary upstream URL: ", conf.upstream, " -- ",domain)
+            kong.log.debug("Routing to secondary upstream URL: ", conf.upstream)
             local ok, err = kong.service.set_upstream(conf.upstream)
             if not ok then
-                kong.log.err("Error going to upstream: ",conf.upstream," -- ",err)
+                kong.log.err("Error going to upstream: ", conf.upstream," -- ",err)
             end
         else
-            -- For Kong 2.X
-            kong.log.debug("Routing to secondary target URL: ", domain)
-            kong.service.set_target(domain, conf.port)
+            -- For Kong 2.X+
+            kong.log.debug("Routing to secondary target URL: ", conf.domain)
+            kong.service.set_target(conf.domain, conf.port)
         end
 
         -- Add header to response to identify the actual host
-        kong.response.add_header("X-NP-Routing", "1")
-      
+        -- kong.response.add_header("X-NP-Routing", "1")
+        kong.response.add_header(UPSTREAM_FORCE_HEADER_NAME, "1")
+
         if conf.preserve_host == true then
             kong.service.request.set_header("Host", kong.request.get_host())
         else
-            kong.service.request.set_header("Host", domain)
+            kong.service.request.set_header("Host", conf.domain)
         end
-      
-        if conf.disable_np_host ~= true then
-            kong.service.request.set_header("X-NP-Host", domain)
-        end
+
+        -- if conf.disable_np_host ~= true then
+        --     kong.service.request.set_header("X-NP-Host", domain)
+        -- end
     else
+        kong.response.add_header(UPSTREAM_FORCE_HEADER_NAME, "0")
         -- Only for logging in case of default routing
         if conf.upstream then
             -- For Kong 3.X
-            kong.log.debug("Routing to primary upstream URL: ", conf.upstream, " -- ",domain)
+            kong.log.debug("Routing to primary upstream URL: ", conf.upstream)
         else
-            -- For Kong 2.X
-            kong.log.debug("Routing to pimary target URL: ", domain)
+            -- For Kong 2.X+
+            kong.log.debug("Routing to pimary target URL: ", conf.domain)
+        end
+    end
+end
+
+local function cookie_is_in_jar(cookie)
+    local key_val = split(cookie, "=")
+    if key_val[1] == UPSTREAM_FORCE_HEADER_NAME then
+        return true
+    end
+    return false
+end
+
+local function bake_cookie(cookie_conf)
+    local cookie_val = kong.response.get_header(UPSTREAM_FORCE_HEADER_NAME)
+    local cookie = {}
+    if cookie_conf.max_age then
+        cookie.max_age = cookie_conf.max_age
+    end
+    if cookie_conf.path then
+        cookie.path = cookie_conf.path
+    end
+    if cookie_conf.same_site then
+        cookie.same_site = cookie_conf.same_site
+    end
+    return UPSTREAM_FORCE_HEADER_NAME .. "=" .. cookie_val
+        .. (cookie.max_age and "; Max-Age=" .. cookie.max_age or "")
+        .. (cookie.path and "; Path=" .. cookie.path or "")
+        .. (cookie_conf.secure and "; Secure" or "")
+        .. (cookie_conf.http_only and "; HttpOnly" or "")
+        .. (cookie.same_site and "; SameSite=" .. cookie.same_site or "")
+end
+
+function NpTrafficSplitterHandler:header_filter(conf)
+    if conf.use_cookies and conf.use_cookies.enabled and cookies then
+        local cookie_header = kong.response.get_header("Set-Cookie")
+        local cookie_type = type(cookie_header)
+        if cookie_type == "string" then
+            if not cookie_is_in_jar(cookie_header) then
+                cookies = {}
+                cookies[1] = cookie_header
+                cookies[2] = bake_cookie(conf.use_cookies)
+                kong.response.set_header("Set-Cookie", cookies)
+            end
+        elseif cookie_type == "table" then
+            local cookie_header_size = #cookie_header
+            for i = 1, cookie_header_size do
+                if not upstream_cookie_exists then
+                    upstream_cookie_exists = cookie_is_in_jar(cookie_header[i])
+                end
+            end
+            if not upstream_cookie_exists then
+                cookie_header[cookie_header_size + 1] = bake_cookie(conf.use_cookies)
+                kong.response.set_header("Set-Cookie", cookie_header)
+            end
+        else
+            kong.response.set_header("Set-Cookie", bake_cookie(conf.use_cookies))
         end
     end
 end

--- a/np-traffic-splitter/handler_spec.lua
+++ b/np-traffic-splitter/handler_spec.lua
@@ -9,6 +9,7 @@ describe("NpTrafficSplitterHandler", function()
         request = {
           set_scheme = function() end,
           set_header = function() end,
+          get_header = function() return "" end,
         },
         set_target = function() end,
         set_upstream = function() end,
@@ -19,6 +20,7 @@ describe("NpTrafficSplitterHandler", function()
       },
       response = {
         add_header = function() end,
+        get_header = function() return "" end,
       },
       log = {
         debug = function() end,

--- a/np-traffic-splitter/schema.lua
+++ b/np-traffic-splitter/schema.lua
@@ -1,17 +1,116 @@
 return {
   name = "np-traffic-splitter",
   fields = {
-    { config = {
+    {
+      config = {
         type = "record",
         fields = {
-          { traffic_percentage_for_secondary = { type = "number", required = true, between = {0, 100} } },
-          { domain = { type = "string", required = true } },
-          { disable_np_host = {type="boolean", required = false, default = false}},
-          { port = {type="number", required = false, default = 443}},
-          { schema = {type="string", required = false, default = "https"}},
-          { preserve_host = {type="boolean", required = false, default = true}},
-          { upstream = {type="string", required = false}},
-
+          {
+            traffic_percentage_for_secondary = {
+              type = "number",
+              required = true,
+              between = {0, 100}
+            }
+          },
+          {
+            domain = {
+              type = "string",
+              required = false
+            }
+          },
+          {
+            disable_np_host = {
+              type="boolean",
+              required = false,
+              default = false
+            }
+          },
+          {
+            port = {
+              type="number",
+              required = false,
+              default = 443
+            }
+          },
+          {
+            schema = {
+              type="string",
+              required = false,
+              default = "https"
+            }
+          },
+          {
+            preserve_host = {
+              type = "boolean",
+              required = false,
+              default = true
+            }
+          },
+          {
+            upstream = {
+              type = "string",
+              required = false
+            }
+          },
+          {
+            use_cookies = {
+              type = "record",
+              required = false,
+              fields = {
+                {
+                  enabled = {
+                    type = "boolean",
+                    required = false,
+                    default = false
+                  }
+                },
+                {
+                  max_age = {
+                    type = "number",
+                    required = false,
+                    default = 300
+                  }
+                },
+                {
+                  path = {
+                    type = "string",
+                    required = false
+                  }
+                },
+                {
+                  secure = {
+                    type = "boolean",
+                    required = false
+                  }
+                },
+                {
+                  http_only = {
+                    type = "boolean",
+                    required = false,
+                  }
+                },
+                {
+                  same_site = {
+                    type = "string",
+                    required = false,
+                    one_of = {
+                      "Strict",
+                      "Lax",
+                      "None"
+                    }
+                  }
+                },
+              }
+            }
+          },
+        },
+        entity_checks = {
+          {
+            at_least_one_of = {
+              "domain",
+              "upstream"
+            }
+          },
         },
       },
     },


### PR DESCRIPTION
In case of different upstreams which may have different assets:

1. Add header_filter phase to set cookies with a flag for the chosen upstream.
2. In the access phase, if a flag wasn't chosen by using the "force" header, then the plugin will read cookies and try to find it there.
3. Edit schema to add optional cookie feature
4. Fix schema so that domain will only be required if an upstream isn't set (and viceversa).
5. Edit sample kong.yaml to add cookie feature.